### PR TITLE
Fixed segfault, this is C code not C++

### DIFF
--- a/src/Rope.c
+++ b/src/Rope.c
@@ -48,13 +48,15 @@ Rope* Rebalance(Rope* R) {
 char* String(Rope* R) {
     char* strx = malloc(sizeof(char) * 2 * R->Weight);
 
-    if (R->Value == "" && R->Left != NULL) {
+    if ((strcmp(R->Value, "") == 0)&& R->Left != NULL) {
         strncat(strx, String(R->Left), strlen(String(R->Left)));
     }
 
-    if (R->Value == "" && R->Right != NULL) {
+    if ((strcmp(R->Value, "") == 0) && R->Right != NULL) {
         strncat(strx, String(R->Right), strlen(String(R->Right)));
     }
+
+    return strx;
 }
 
 void Insert(Rope* R, char* c, int pos) {

--- a/src/Rope.h
+++ b/src/Rope.h
@@ -1,10 +1,8 @@
 #include "stdio.h"
 #include "string.h"
 #include "malloc.h"
-typedef struct Rope Rope;
-
-typedef struct Rope {
-    Rope* Left, *Right;
+typedef struct _Rope {
+    struct _Rope *Left, *Right;
     int Weight;
     char* Value;
 } Rope;


### PR DESCRIPTION
In c you cannot declare a struct twice, they normal way is to do a typedef and when we want to refer to the struct within the struct when use a temporary name.

The segfault was fixed as the String() method didn't return anything so the pointer was assigned a random value.